### PR TITLE
switched docker image to cimg/node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,1 @@
-FROM node:lts-alpine
-
-# Update repositories
-RUN apk update
-
-# Development utilities
-RUN apk add --no-cache git
-RUN apk add --no-cache python3
-RUN apk add --no-cache build-base
-RUN apk add --no-cache yarn
-
-# Docker
-RUN apk add --no-cache docker-cli
-RUN apk add --no-cache --virtual .docker-compose-deps \
-    python3-dev libffi-dev openssl-dev py3-pip rust \
-    cargo openssl
-RUN pip3 install docker-compose
+FROM cimg/node:10.24


### PR DESCRIPTION
I've tried to downgrade to node:12-alpine but I still had building issues... In the end it works with node 10 and this is the best 'official' image I could find. It already includes git, python3, yarn and docker.

With this image `yarn`, `yarn compile` and `yarn test` work out of the box